### PR TITLE
Update SecurityConfig.java

### DIFF
--- a/src/main/java/securityuwierzytelnianie/SecurityConfig.java
+++ b/src/main/java/securityuwierzytelnianie/SecurityConfig.java
@@ -21,9 +21,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
 	}
 	
 	  protected void configure(AuthenticationManagerBuilder auth) throws Exception {
-	        auth.inMemoryAuthentication()
-	     
-	          .withUser("admin").password("qwerty").roles("ADMIN");
+	        auth.userDetailsService(customUserDetailsService());
 	    }
 	@SuppressWarnings("deprecation")
 	  @Bean


### PR DESCRIPTION
Nie mogłeś się zalogować, dlatego że Spring nie pobierał danych z bazy, ale tworzył użytkownika w pamięci. Formularz logowania działa poprawnie, ale działał tylko dla użytkownika "admin" i hasła "qwerty". Teraz powinno działać.